### PR TITLE
#1 update gtp5g to 0.9.11

### DIFF
--- a/pkgs/gtp5g/default.nix
+++ b/pkgs/gtp5g/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gtp5g";
-  version = "1.0"; # Adjust version as necessary
+  version = "1.1"; # Adjust version as necessary
 
   src = fetchFromGitHub {
     owner = "free5gc";
     repo = "gtp5g";
-    rev = "v0.9.1";
-    sha256 = "n4YhgySVjceRRHxoaGd4Z+Rf2MgD6+upZTcS6xMLLJ0=";
+    rev = "v0.9.11";
+    sha256 = "sha256-jnme3cOKhNZ1mTVOpSKZioj6u0sh+ZGC1IuzsNsw5Gg=";
   };
 
  # patches = [ ./nix.patch ];
@@ -39,4 +39,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/gtp5g/default.nix
+++ b/pkgs/gtp5g/default.nix
@@ -22,14 +22,13 @@ stdenv.mkDerivation rec {
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
-#  installTargets = [ "install" ];
 	installPhase = ''
+    runHook preInstall
 
-		mkdir -p $out/lib/modules/$kernel.version/kernel/drivers/net
-		cp gtp5g.ko $out/lib/modules/$kernel.version/kernel/drivers/net/
+    install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gtp5g
+
+    runHook postInstall
 	'';
-
-		#modprobe gtp5g
 
 
   meta = with lib; {

--- a/pkgs/gtp5g/default.nix
+++ b/pkgs/gtp5g/default.nix
@@ -22,14 +22,13 @@ stdenv.mkDerivation rec {
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
-	installPhase = ''
+  installPhase = ''
     runHook preInstall
 
     install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gtp5g
 
     runHook postInstall
-	'';
-
+  '';
 
   meta = with lib; {
     description = "GTPv5 Kernel Module";


### PR DESCRIPTION
Hello,

This merge request resolve #1 
It's update the gtp5g to last v0.9.11 version

I tested it locally like described above:
```shell
% sudo modprobe /nix/store/mzqfsw9a1ywxryqgjv0ikzjssmmaph94-gtp5g-1.1/lib/modules/.version/kernel/drivers/net/gtp5g.ko
% lsmod | grep gtp
gtp5g                 208896  0
udp_tunnel             32768  2 gtp5g,sctp
```