### PR TITLE
Gtp5g module

### DIFF
--- a/pkgs/gtp5g/default.nix
+++ b/pkgs/gtp5g/default.nix
@@ -22,14 +22,13 @@ stdenv.mkDerivation rec {
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
-#  installTargets = [ "install" ];
 	installPhase = ''
+    runHook preInstall
 
-		mkdir -p $out/lib/modules/$kernel.version/kernel/drivers/net
-		cp gtp5g.ko $out/lib/modules/$kernel.version/kernel/drivers/net/
+    install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gtp5g
+
+    runHook postInstall
 	'';
-
-		#modprobe gtp5g
 
 
   meta = with lib; {

--- a/pkgs/gtp5g/default.nix
+++ b/pkgs/gtp5g/default.nix
@@ -22,14 +22,13 @@ stdenv.mkDerivation rec {
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
-	installPhase = ''
+  installPhase = ''
     runHook preInstall
 
     install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gtp5g
 
     runHook postInstall
-	'';
-
+  '';
 
   meta = with lib; {
     description = "GTPv5 Kernel Module";


### PR DESCRIPTION
Hello,

This MR is a refacto of how to install the gtp5g module into NixOS

I tested it like described above:
```shell
%  lsmod | grep gtp
gtp5g                 208896  0
udp_tunnel             32768  2 gtp5g,sctp
``` 